### PR TITLE
chore: add approve build for pnpm ver 10.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,5 +42,10 @@
     "unbuild": "^3.5.0",
     "zod": "^3.24.2",
     "zod-to-json-schema": "^3.24.5"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change adds a `pnpm` configuration to specify that only the `esbuild` dependency should be built.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R45-R49): Added a `pnpm` configuration with `onlyBuiltDependencies` set to `esbuild`.